### PR TITLE
Serialize trie as JSON so it can be required in the browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 data.json
-data.trie
+trie.json
 .DS_Store
 node_modules/
 *.js

--- a/generate.coffee
+++ b/generate.coffee
@@ -78,7 +78,10 @@ for codePoint in codePoints when codePoint?
   
   trie.set codePoint.code, val
 
-fs.writeFileSync 'data.trie', trie.toBuffer()
+# Trie is serialized suboptimally as JSON so it can be loaded via require,
+# allowing unicode-properties to work in the browser
+fs.writeFileSync 'trie.json', JSON.stringify trie.toBuffer()
+
 fs.writeFileSync 'data.json', JSON.stringify
   categories: Object.keys(categories)
   combiningClasses: Object.keys(combiningClasses)

--- a/index.coffee
+++ b/index.coffee
@@ -1,7 +1,11 @@
 UnicodeTrie = require 'unicode-trie'
 data = require './data.json'
-fs = require 'fs'
-trie = new UnicodeTrie fs.readFileSync __dirname + '/data.trie'
+
+# Trie is serialized as a Buffer in node, but here
+# we may be running in a browser so we make an Uint8Array
+trieBuffer = require './trie.json'
+trieData = new Uint8Array trieBuffer.data
+trie = new UnicodeTrie trieData
 
 log2 = Math.log2 or (n) ->
   Math.log(n) / Math.LN2


### PR DESCRIPTION
This allows unicode-properties to work in the browser, dropping the dependency on node's fs module.

Fixes #1