### PR TITLE
Separate node and browser builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 data.json
 data.trie
+trie.json
 .DS_Store
 node_modules/
 dist/

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,9 @@
+import UnicodeTrie from 'unicode-trie';
+import data from './data.json';
+import trieData from './trie.json';
+import buildUnicodeProperties from './index';
+
+const trie = new UnicodeTrie(new Uint8Array(trieData.data));
+const unicodeProperties = buildUnicodeProperties(data, trie);
+
+export default unicodeProperties;

--- a/browser.js
+++ b/browser.js
@@ -3,7 +3,7 @@ import data from './data.json';
 import trieData from './trie.json';
 import buildUnicodeProperties from './index';
 
-const trie = new UnicodeTrie(new Uint8Array(trieData.data));
+const trie = new UnicodeTrie(Buffer.from(trieData.data, 'base64'));
 const unicodeProperties = buildUnicodeProperties(data, trie);
 
 export default unicodeProperties;

--- a/generate.js
+++ b/generate.js
@@ -101,3 +101,7 @@ fs.writeFileSync('./data.json', JSON.stringify({
   scripts: Object.keys(scripts),
   eaw: Object.keys(eaws)
 }));
+
+// Trie is serialized suboptimally as JSON so it can be loaded via require,
+// allowing unicode-properties to work in the browser
+fs.writeFileSync('./trie.json', JSON.stringify(trie.toBuffer()));

--- a/generate.js
+++ b/generate.js
@@ -104,4 +104,4 @@ fs.writeFileSync('./data.json', JSON.stringify({
 
 // Trie is serialized suboptimally as JSON so it can be loaded via require,
 // allowing unicode-properties to work in the browser
-fs.writeFileSync('./trie.json', JSON.stringify(trie.toBuffer()));
+fs.writeFileSync('./trie.json', JSON.stringify({ data: trie.toBuffer().toString('base64') }));

--- a/index.js
+++ b/index.js
@@ -1,169 +1,168 @@
-import fs from 'fs';
-import UnicodeTrie from 'unicode-trie';
-import data from './data.json';
-
-const trie = new UnicodeTrie(fs.readFileSync(__dirname + '/data.trie'));
 const log2 = Math.log2 || (n => Math.log(n) / Math.LN2);
 const bits = (n) => ((log2(n) + 1) | 0);
 
-// compute the number of bits stored for each field
-const CATEGORY_BITS = bits(data.categories.length - 1);
-const COMBINING_BITS = bits(data.combiningClasses.length - 1);
-const SCRIPT_BITS = bits(data.scripts.length - 1);
-const EAW_BITS = bits(data.eaw.length - 1);
-const NUMBER_BITS = 10;
+const buildUnicodeProperties = (data, trie) => {
+  // compute the number of bits stored for each field
+  const CATEGORY_BITS = bits(data.categories.length - 1);
+  const COMBINING_BITS = bits(data.combiningClasses.length - 1);
+  const SCRIPT_BITS = bits(data.scripts.length - 1);
+  const EAW_BITS = bits(data.eaw.length - 1);
+  const NUMBER_BITS = 10;
 
-// compute shift and mask values for each field
-const CATEGORY_SHIFT = COMBINING_BITS + SCRIPT_BITS + EAW_BITS + NUMBER_BITS;
-const COMBINING_SHIFT = SCRIPT_BITS + EAW_BITS + NUMBER_BITS;
-const SCRIPT_SHIFT = EAW_BITS + NUMBER_BITS;
-const EAW_SHIFT = NUMBER_BITS;
-const CATEGORY_MASK = (1 << CATEGORY_BITS) - 1;
-const COMBINING_MASK = (1 << COMBINING_BITS) - 1;
-const SCRIPT_MASK = (1 << SCRIPT_BITS) - 1;
-const EAW_MASK = (1 << EAW_BITS) - 1;
-const NUMBER_MASK = (1 << NUMBER_BITS) - 1;
+  // compute shift and mask values for each field
+  const CATEGORY_SHIFT = COMBINING_BITS + SCRIPT_BITS + EAW_BITS + NUMBER_BITS;
+  const COMBINING_SHIFT = SCRIPT_BITS + EAW_BITS + NUMBER_BITS;
+  const SCRIPT_SHIFT = EAW_BITS + NUMBER_BITS;
+  const EAW_SHIFT = NUMBER_BITS;
+  const CATEGORY_MASK = (1 << CATEGORY_BITS) - 1;
+  const COMBINING_MASK = (1 << COMBINING_BITS) - 1;
+  const SCRIPT_MASK = (1 << SCRIPT_BITS) - 1;
+  const EAW_MASK = (1 << EAW_BITS) - 1;
+  const NUMBER_MASK = (1 << NUMBER_BITS) - 1;
 
-export const getCategory = (codePoint) => {
-  const val = trie.get(codePoint);
-  return data.categories[(val >> CATEGORY_SHIFT) & CATEGORY_MASK];
-};
+  const getCategory = (codePoint) => {
+    const val = trie.get(codePoint);
+    return data.categories[(val >> CATEGORY_SHIFT) & CATEGORY_MASK];
+  };
 
-export const getCombiningClass = (codePoint) => {
-  const val = trie.get(codePoint);
-  return data.combiningClasses[(val >> COMBINING_SHIFT) & COMBINING_MASK];
-};
+  const getCombiningClass = (codePoint) => {
+    const val = trie.get(codePoint);
+    return data.combiningClasses[(val >> COMBINING_SHIFT) & COMBINING_MASK];
+  };
 
-export const getScript = (codePoint) => {
-  const val = trie.get(codePoint);
-  return data.scripts[(val >> SCRIPT_SHIFT) & SCRIPT_MASK];
-};
+  const getScript = (codePoint) => {
+    const val = trie.get(codePoint);
+    return data.scripts[(val >> SCRIPT_SHIFT) & SCRIPT_MASK];
+  };
 
-export const getEastAsianWidth = (codePoint) => {
-  const val = trie.get(codePoint);
-  return data.eaw[(val >> EAW_SHIFT) & EAW_MASK];
-};
+  const getEastAsianWidth = (codePoint) => {
+    const val = trie.get(codePoint);
+    return data.eaw[(val >> EAW_SHIFT) & EAW_MASK];
+  };
 
-export const getNumericValue = (codePoint) => {
-  let val = trie.get(codePoint);
-  let num = val & NUMBER_MASK;
+  const getNumericValue = (codePoint) => {
+    let val = trie.get(codePoint);
+    let num = val & NUMBER_MASK;
 
-  if (num === 0) {
-    return null;
-  } else if (num <= 50) {
-    return num - 1;
-  } else if (num < 0x1e0) {
-    const numerator = (num >> 4) - 12;
-    const denominator = (num & 0xf) + 1;
-    return numerator / denominator;
-  } else if (num < 0x300) {
-    val = (num >> 5) - 14;
-    let exp = (num & 0x1f) + 2;
+    if (num === 0) {
+      return null;
+    } else if (num <= 50) {
+      return num - 1;
+    } else if (num < 0x1e0) {
+      const numerator = (num >> 4) - 12;
+      const denominator = (num & 0xf) + 1;
+      return numerator / denominator;
+    } else if (num < 0x300) {
+      val = (num >> 5) - 14;
+      let exp = (num & 0x1f) + 2;
 
-    while (exp > 0) {
-      val *= 10;
-      exp--;
+      while (exp > 0) {
+        val *= 10;
+        exp--;
+      }
+      return val;
+    } else {
+      val = (num >> 2) - 0xbf;
+      let exp = (num & 3) + 1;
+      while (exp > 0) {
+        val *= 60;
+        exp--;
+      }
+      return val;
     }
-    return val;
-  } else {
-    val = (num >> 2) - 0xbf;
-    let exp = (num & 3) + 1;
-    while (exp > 0) {
-      val *= 60;
-      exp--;
-    }
-    return val;
+  };
+
+  const isAlphabetic = (codePoint) => {
+    const category = getCategory(codePoint);
+    return (
+      category === 'Lu' ||
+      category === 'Ll' ||
+      category === 'Lt' ||
+      category === 'Lm' ||
+      category === 'Lo' ||
+      category === 'Nl'
+    )
+  };
+
+  const isDigit = (codePoint) => (
+    getCategory(codePoint) === 'Nd'
+  );
+
+  const isPunctuation = (codePoint) => {
+    const category = getCategory(codePoint);
+    return (
+      category === 'Pc' ||
+      category === 'Pd' ||
+      category === 'Pe' ||
+      category === 'Pf' ||
+      category === 'Pi' ||
+      category === 'Po' ||
+      category === 'Ps'
+    );
+  };
+
+  const isLowerCase = (codePoint) => {
+    return getCategory(codePoint) === 'Ll';
+  };
+
+  const isUpperCase = (codePoint) => (
+    getCategory(codePoint) === 'Lu'
+  );
+
+  const isTitleCase = (codePoint) => (
+    getCategory(codePoint) === 'Lt'
+  );
+
+  const isWhiteSpace = (codePoint) => {
+    const category = getCategory(codePoint);
+    return (
+      category === 'Zs' ||
+      category === 'Zl' ||
+      category === 'Zp'
+    );
+  };
+
+  const isBaseForm = (codePoint) => {
+    const category = getCategory(codePoint);
+    return (
+      category === 'Nd' ||
+      category === 'No' ||
+      category === 'Nl' ||
+      category === 'Lu' ||
+      category === 'Ll' ||
+      category === 'Lt' ||
+      category === 'Lm' ||
+      category === 'Lo' ||
+      category === 'Me' ||
+      category === 'Mc'
+    )
+  };
+
+  const isMark = (codePoint) => {
+    const category = getCategory(codePoint);
+    return (
+      category === 'Mn' ||
+      category === 'Me' ||
+      category === 'Mc'
+    );
+  };
+
+  return {
+    getCategory,
+    getCombiningClass,
+    getScript,
+    getEastAsianWidth,
+    getNumericValue,
+    isAlphabetic,
+    isDigit,
+    isPunctuation,
+    isLowerCase,
+    isUpperCase,
+    isTitleCase,
+    isWhiteSpace,
+    isBaseForm,
+    isMark
   }
-};
-
-export const isAlphabetic = (codePoint) => {
-  const category = getCategory(codePoint);
-  return (
-    category === 'Lu' ||
-    category === 'Ll' ||
-    category === 'Lt' ||
-    category === 'Lm' ||
-    category === 'Lo' ||
-    category === 'Nl'
-  )
-};
-
-export const isDigit = (codePoint) => (
-  getCategory(codePoint) === 'Nd'
-);
-
-export const isPunctuation = (codePoint) => {
-  const category = getCategory(codePoint);
-  return (
-    category === 'Pc' ||
-    category === 'Pd' ||
-    category === 'Pe' ||
-    category === 'Pf' ||
-    category === 'Pi' ||
-    category === 'Po' ||
-    category === 'Ps'
-  );
-};
-
-export const isLowerCase = (codePoint) => {
-  return getCategory(codePoint) === 'Ll';
-};
-
-export const isUpperCase = (codePoint) => (
-  getCategory(codePoint) === 'Lu'
-);
-
-export const isTitleCase = (codePoint) => (
-  getCategory(codePoint) === 'Lt'
-);
-
-export const isWhiteSpace = (codePoint) => {
-  const category = getCategory(codePoint);
-  return (
-    category === 'Zs' ||
-    category === 'Zl' ||
-    category === 'Zp'
-  );
-};
-
-export const isBaseForm = (codePoint) => {
-  const category = getCategory(codePoint);
-  return (
-    category === 'Nd' ||
-    category === 'No' ||
-    category === 'Nl' ||
-    category === 'Lu' ||
-    category === 'Ll' ||
-    category === 'Lt' ||
-    category === 'Lm' ||
-    category === 'Lo' ||
-    category === 'Me' ||
-    category === 'Mc'
-  )
-};
-
-export const isMark = (codePoint) => {
-  const category = getCategory(codePoint);
-  return (
-    category === 'Mn' ||
-    category === 'Me' ||
-    category === 'Mc'
-  );
-};
-
-export default {
-  getCategory,
-  getCombiningClass,
-  getScript,
-  getEastAsianWidth,
-  getNumericValue,
-  isAlphabetic,
-  isDigit,
-  isPunctuation,
-  isLowerCase,
-  isUpperCase,
-  isTitleCase,
-  isWhiteSpace,
-  isBaseForm,
-  isMark
 }
+
+export default buildUnicodeProperties;

--- a/node.js
+++ b/node.js
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import UnicodeTrie from 'unicode-trie';
+import data from './data.json';
+import buildUnicodeProperties from './index';
+
+const trie = new UnicodeTrie(fs.readFileSync(__dirname + '/data.trie'));
+const unicodeProperties = buildUnicodeProperties(data, trie);
+
+module.exports = unicodeProperties;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Provides fast access to unicode character properties",
   "main": "./unicode-properties.cjs.js",
   "module": "./unicode-properties.es.js",
+  "browser": {
+    "./unicode-properties.es.js": "./unicode-properties.browser.es.js",
+    "./unicode-properties.cjs.js": "./unicode-properties.browser.cjs.js"
+  },
   "directories": {
     "test": "test"
   },
@@ -16,7 +20,7 @@
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
-    "codepoints": "^1.2.0",
+    "codepoints": "^1.2.1",
     "mocha": "^5.2.0",
     "rollup": "^0.52.2",
     "rollup-plugin-babel": "^2.7.1"
@@ -44,8 +48,11 @@
   "files": [
     "./data.json",
     "./data.trie",
+    "./trie.json",
+    "./unicode-properties.es.js",
     "./unicode-properties.cjs.js",
-    "./unicode-properties.esm.js",
+    "./unicode-properties.browser.es.js",
+    "./unicode-properties.browser.cjs.js"
   ],
   "author": "Devon Govett <devongovett@gmail.com>",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,6 @@ const getCJS = override => Object.assign({}, cjs, override)
 const getESM = override => Object.assign({}, esm, override)
 
 const configBase = {
-  input: './index.js',
   plugins: [
     babel({
       babelrc: false,
@@ -22,17 +21,36 @@ const configBase = {
       plugins: [ 'external-helpers'],
       exclude: 'node_modules/**'
     })
+  ]
+}
+
+const nodeConfig = Object.assign({}, configBase, {
+  input: './node.js',
+  output: [
+    getESM({ file: './unicode-properties.es.js' }),
+    getCJS({ file: './unicode-properties.cjs.js' }),
   ],
   external: Object.keys(dependencies).concat([
     'fs',
     `${__dirname}/data.json`
-  ]),
+  ])
+});
+
+
+const browserConfig = Object.assign({}, configBase, {
+  input: './browser.js',
   output: [
-    getESM({ file: './unicode-properties.esm.js' }),
-    getCJS({ file: './unicode-properties.cjs.js' }),
-  ]
-}
+    getESM({ file: './unicode-properties.browser.es.js' }),
+    getCJS({ file: './unicode-properties.browser.cjs.js' }),
+  ],
+  external: Object.keys(dependencies).concat([
+    `${__dirname}/data.json`,
+    `${__dirname}/trie.json`
+  ])
+});
+
 
 export default [
-  configBase
+  nodeConfig,
+  browserConfig
 ]

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
-const unicode = require('../index.js');
 const assert = require('assert');
+const unicode = require('../node.js');
 
 describe('unicode-properties', () => {
   it('getCategory', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,7 +460,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-codepoints@^1.2.0:
+codepoints@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/codepoints/-/codepoints-1.2.1.tgz#4c2f9233db3d5a7fc443144db0f5adaf5e805a55"
 


### PR DESCRIPTION
- Create separate entry points for browser and node builds
- Separate lib real logic from entry points as a function that takes data and trie info 
- Make package json point to appropriate build for each env

@devongovett what do you think? I think I can change this approach to have one single entry point for both envs if you like, but probably going to require some conditionals and extra config on the rollup side.

I'll ultimately need your help for publishing 😄 