### PR TITLE
Use path.join for file paths, fixes pkg support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 import fs from 'fs';
+import path from 'path';
 import UnicodeTrie from 'unicode-trie';
 import data from './data.json';
 
-const trie = new UnicodeTrie(fs.readFileSync(__dirname + '/data.trie'));
+const trie = new UnicodeTrie(fs.readFileSync(path.join(__dirname, 'data.trie')));
 const log2 = Math.log2 || (n => Math.log(n) / Math.LN2);
 const bits = (n) => ((log2(n) + 1) | 0);
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "./data.json",
     "./data.trie",
     "./unicode-properties.cjs.js",
-    "./unicode-properties.esm.js",
+    "./unicode-properties.esm.js"
   ],
   "author": "Devon Govett <devongovett@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Using path.join allows pkg to bundle files into the binary, otherwise the binary crashes trying to load the classes.trie file. Found while trying to use pdfmake on our server.