### PR TITLE
Do not emit interopDefault helper in commonjs builds

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,8 @@ import { dependencies } from './package.json'
 
 const cjs = {
   format: 'cjs',
-  sourcemap: true
+  sourcemap: true,
+  interop: false
 }
 
 const esm = {


### PR DESCRIPTION
This generates cleaner, smaller code.

Makes easier to use webpack / brfs on node: https://github.com/foliojs/pdfkit/issues/990